### PR TITLE
feat: Add CallAllContracts to config

### DIFF
--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -98,6 +98,10 @@ type TestingConfig struct {
 	// assertion, optimization, custom) are found.
 	StopOnNoTests bool `json:"stopOnNoTests"`
 
+	// CallAllContracts indicates whether all contracts should be called (including dynamically deployed ones), rather
+	// than just the contracts specified in the project configuration's deployment order.
+	CallAllContracts bool `json:"callAllContracts"`
+
 	// TestAllContracts indicates whether all contracts should be tested (including dynamically deployed ones), rather
 	// than just the contracts specified in the project configuration's deployment order.
 	TestAllContracts bool `json:"testAllContracts"`

--- a/fuzzing/config/config_defaults.go
+++ b/fuzzing/config/config_defaults.go
@@ -55,6 +55,7 @@ func GetDefaultProjectConfig(platform string) (*ProjectConfig, error) {
 				StopOnFailedTest:             true,
 				StopOnFailedContractMatching: false,
 				StopOnNoTests:                true,
+				CallAllContracts:             false,
 				TestAllContracts:             false,
 				TraceAll:                     false,
 				AssertionTesting: AssertionTestingConfig{

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -152,8 +152,8 @@ func (fw *FuzzerWorker) getNewCorpusCallSequenceWeight() *big.Int {
 // onChainContractDeploymentAddedEvent is the event callback used when the chain detects a new contract deployment.
 // It attempts bytecode matching and updates the list of deployed contracts the worker should use for fuzz testing.
 func (fw *FuzzerWorker) onChainContractDeploymentAddedEvent(event chain.ContractDeploymentsAddedEvent) error {
-	// Do not track the deployed contract if the contract deployment was a dynamic one and testAllContracts is false
-	if !fw.fuzzer.config.Fuzzing.Testing.TestAllContracts && event.DynamicDeployment {
+	// Do not track the deployed contract if the contract deployment was a dynamic one and both callAllContracts and testAllContracts are false
+	if !fw.fuzzer.config.Fuzzing.Testing.CallAllContracts && !fw.fuzzer.config.Fuzzing.Testing.TestAllContracts && event.DynamicDeployment {
 		return nil
 	}
 


### PR DESCRIPTION
I added the "CallAllContracts" option to the TestingConfig struct which describes the configuration options used for testing. I also added it to the config defaults that will be used if one is not provided during fuzzing.