### PR TITLE
Detect transaction with larger gas usage

### DIFF
--- a/fuzzing/config/config.go
+++ b/fuzzing/config/config.go
@@ -89,6 +89,9 @@ type FuzzingConfig struct {
 	// TransactionGasLimit describes the maximum amount of gas that will be used by the fuzzer generated transactions.
 	TransactionGasLimit uint64 `json:"transactionGasLimit"`
 
+	// MonitorGasUsage describes whether the transaction with the highest gas usage should be recorded by the fuzzer.
+	MonitorGasUsage bool `json:"monitorGasUsage"`
+
 	// Testing describes the configuration used for different testing strategies.
 	Testing TestingConfig `json:"testing"`
 

--- a/fuzzing/config/config_defaults.go
+++ b/fuzzing/config/config_defaults.go
@@ -53,6 +53,7 @@ func GetDefaultProjectConfig(platform string) (*ProjectConfig, error) {
 			MaxBlockTimestampDelay: 604800,
 			BlockGasLimit:          125_000_000,
 			TransactionGasLimit:    12_500_000,
+			MonitorGasUsage:        false,
 			Testing: TestingConfig{
 				StopOnFailedTest:             true,
 				StopOnFailedContractMatching: false,

--- a/fuzzing/config/gen_fuzzing_config.go
+++ b/fuzzing/config/gen_fuzzing_config.go
@@ -31,6 +31,7 @@ func (f FuzzingConfig) MarshalJSON() ([]byte, error) {
 		MaxBlockTimestampDelay  uint64                    `json:"blockTimestampDelayMax"`
 		BlockGasLimit           uint64                    `json:"blockGasLimit"`
 		TransactionGasLimit     uint64                    `json:"transactionGasLimit"`
+		MonitorGasUsage         bool                      `json:"monitorGasUsage"`
 		Testing                 TestingConfig             `json:"testing"`
 		TestChainConfig         config.TestChainConfig    `json:"chainConfig"`
 	}
@@ -56,6 +57,7 @@ func (f FuzzingConfig) MarshalJSON() ([]byte, error) {
 	enc.MaxBlockTimestampDelay = f.MaxBlockTimestampDelay
 	enc.BlockGasLimit = f.BlockGasLimit
 	enc.TransactionGasLimit = f.TransactionGasLimit
+	enc.MonitorGasUsage = f.MonitorGasUsage
 	enc.Testing = f.Testing
 	enc.TestChainConfig = f.TestChainConfig
 	return json.Marshal(&enc)
@@ -80,6 +82,7 @@ func (f *FuzzingConfig) UnmarshalJSON(input []byte) error {
 		MaxBlockTimestampDelay  *uint64                   `json:"blockTimestampDelayMax"`
 		BlockGasLimit           *uint64                   `json:"blockGasLimit"`
 		TransactionGasLimit     *uint64                   `json:"transactionGasLimit"`
+		MonitorGasUsage         *bool                     `json:"monitorGasUsage"`
 		Testing                 *TestingConfig            `json:"testing"`
 		TestChainConfig         *config.TestChainConfig   `json:"chainConfig"`
 	}
@@ -137,6 +140,9 @@ func (f *FuzzingConfig) UnmarshalJSON(input []byte) error {
 	}
 	if dec.TransactionGasLimit != nil {
 		f.TransactionGasLimit = *dec.TransactionGasLimit
+	}
+	if dec.MonitorGasUsage != nil {
+		f.MonitorGasUsage = *dec.MonitorGasUsage
 	}
 	if dec.Testing != nil {
 		f.Testing = *dec.Testing

--- a/fuzzing/fuzzer_metrics.go
+++ b/fuzzing/fuzzer_metrics.go
@@ -1,9 +1,18 @@
 package fuzzing
 
-import "math/big"
+import (
+	"github.com/crytic/medusa/fuzzing/calls"
+	"math/big"
+)
 
 // FuzzerMetrics represents a struct tracking metrics for a Fuzzer run.
 type FuzzerMetrics struct {
+	// highestGasUsage describes the highest gas usage by a transaction observed across all workers.
+	highestGasUsage *big.Int
+
+	// highestGasUsageTx describes the transaction which has the highest gas usage observed across all workers.
+	highestGasUsageTx *calls.CallSequenceElement
+
 	// workerMetrics describes the metrics for each individual worker. This expands as needed and some slots may be nil
 	// while workers are initializing, as it corresponds to the indexes in Fuzzer.workers.
 	workerMetrics []fuzzerWorkerMetrics
@@ -26,7 +35,9 @@ type fuzzerWorkerMetrics struct {
 func newFuzzerMetrics(workerCount int) *FuzzerMetrics {
 	// Create a new metrics struct and return it with as many slots as required.
 	metrics := FuzzerMetrics{
-		workerMetrics: make([]fuzzerWorkerMetrics, workerCount),
+		highestGasUsage:   big.NewInt(0),
+		highestGasUsageTx: nil,
+		workerMetrics:     make([]fuzzerWorkerMetrics, workerCount),
 	}
 	for i := 0; i < len(metrics.workerMetrics); i++ {
 		metrics.workerMetrics[i].sequencesTested = big.NewInt(0)

--- a/fuzzing/fuzzer_worker.go
+++ b/fuzzing/fuzzer_worker.go
@@ -290,6 +290,9 @@ func (fw *FuzzerWorker) testNextCallSequence() (calls.CallSequence, []ShrinkCall
 
 		// Update our metrics
 		fw.workerMetrics().callsTested.Add(fw.workerMetrics().callsTested, big.NewInt(1))
+		if fw.fuzzer.config.Fuzzing.MonitorGasUsage {
+			fw.fuzzer.updateFuzzerGasUsageMetrics(currentlyExecutedSequence)
+		}
 
 		// If our fuzzer context is done, exit out immediately without results.
 		if utils.CheckContextDone(fw.fuzzer.ctx) {


### PR DESCRIPTION
This PR adds a new config option "monitorGasUsage", a boolean value indicating whether we want medusa to keep track of the transaction that consumed the most gas during the fuzzing process.

Two new fields are added to the fuzzer metrics struct, highestGasUsage and highestGasUsageTx indicating the highest amount of gas used by a transaction and the transaction that used the highest amount of gas respectively.

After fuzzing is completed, we print out the highest amount of gas used and the transaction that consumed the most gas if MonitorGasUsage is enabled in config.